### PR TITLE
Fix/category scroll 스크롤 오른쪽 버튼 클릭 움직임 수정

### DIFF
--- a/src/components/categroyScroll/horizonScroll.tsx
+++ b/src/components/categroyScroll/horizonScroll.tsx
@@ -34,9 +34,9 @@ export default function HorizonScroll({ List }: Props) {
       if (scrollRef.current.scrollLeft + scrollOffset < 200) {
         SetScrollPosition(0)
         scrollRef.current.scrollLeft = 0
-      } else if (scrollRef.current.scrollLeft + scrollOffset > 3500) {
+      } else if (scrollRef.current.scrollLeft + scrollOffset > 3900) {
         SetScrollPosition(1)
-        scrollRef.current.scrollLeft += scrollOffset
+        scrollRef.current.scrollLeft = scrollRef.current.scrollWidth - 1000
       } else {
         SetScrollPosition(2)
       }


### PR DESCRIPTION
버튼을 계속 누르는 경우 마지막까지 스크롤이 이동을 안하는 경우가 생겨 이를 해결함
충돌 사항을 없을것으로 보임 